### PR TITLE
[Chore] Bump bky-as dependency to latest delphi commit

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -8,4 +8,4 @@ functions.
 - Go 1.22
 - Tinygo v0.32.0
 - jq
-- Block Attestation Service CLI version f6a2c0f
+- Block Attestation Service CLI version fd9f4e8


### PR DESCRIPTION
## Describe your changes
Update the example README to specify the version of the bky-as (Delphi CLI) dependency as the latest version of the CLI. 

This was verified by updating the version of `bky-as` I was using to the specified delphi commit, then running `make clean` and `make run`.

## Notes for reviewers

## Checklist before requesting a review
If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [x] Dependencies in `go.mod` only reference tagged or `main` branch commits
- [x] I have run `make pre-pr` and all checks have passed.
- [x] DTO structs have been updated via `make generate`
- [x] The example in the `example` directory has been updated to reflect 
  these changes, if applicable.
- [x] This PR is small. 
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
