### PR TITLE
[BKY-6544] Manage bky-as cli version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 example/x.wasm
 example/result.json
+/tmp

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ WASM runtime.
     - The SDK is designed to work with the Blocky Attestation Service
     - The version compatible with this SDK is pinned in the `shell.nix` file.
 
-Additional project dependencies are specified in tbe `shell.nix` file. 
+Additional project dependencies are specified in tbe `shell.nix` file.
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,35 @@ WASM runtime.
 
 ### Dependencies
 
-- Go 1.22.6
-- Tinygo v0.32.0
+- Go (see `go.mod` for version)
+- Tinygo v0.34.0
+- jq
 - golangci-lint
 - [easyjson](https://github.com/mailru/easyjson) v0.9.0
     - Used for generating JSON serialization code
+- `bky-as` - Blocky Attestation Service
+    - The SDK is designed to work with the Blocky Attestation Service
+    - The version compatible with this SDK is pinned in the `shell.nix` file.
+
+Additional project dependencies are specified in tbe `shell.nix` file. 
 
 ### Development
+
+### Nix Shell
+To enter a development shell with all dependencies, run:
+
+```bash
+nix-shell --pure
+```
+
+The development shell can be started with a specific version of `bky-as` by
+specifying the version via the `--argstr` flag:
+
+```bash
+nix-shell --pure --argstr bkyas_version v0.1.0-beta.5 # stable version
+nix-shell --pure --argstr bkyas_version <full git commit sha> # specific unstable version
+nix-shell --pure --argstr bkyas_version latest # latest unstable version
+```
 
 #### Testing
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The development shell can be started with a specific version of `bky-as` by
 specifying the version via the `--argstr` flag:
 
 ```bash
-nix-shell --pure --argstr bkyas_version v0.1.0-beta.5 # stable version
-nix-shell --pure --argstr bkyas_version <full git commit sha> # specific unstable version
-nix-shell --pure --argstr bkyas_version latest # latest unstable version
+nix-shell --pure --argstr bkyAsVersion v0.1.0-beta.5 # stable version
+nix-shell --pure --argstr bkyAsVersion <full git commit sha> # specific unstable version
+nix-shell --pure --argstr bkyAsVersion latest # latest unstable version
 ```
 
 #### Testing

--- a/example/Makefile
+++ b/example/Makefile
@@ -23,4 +23,4 @@ run: result.json
 	@jq -r '.transitive_attested_function_call.logs | @base64d' result.json
 
 clean:
-	rm -f x.wasm result.json
+	rm x.wasm result.json

--- a/example/Makefile
+++ b/example/Makefile
@@ -23,4 +23,4 @@ run: result.json
 	@jq -r '.transitive_attested_function_call.logs | @base64d' result.json
 
 clean:
-	rm x.wasm result.json
+	rm -f x.wasm result.json

--- a/example/README.md
+++ b/example/README.md
@@ -8,4 +8,4 @@ functions.
 - Go (see go.mod for version)
 - Tinygo v0.34.0
 - jq
-- Block Attestation Service CLI (see shell.nix for version)
+- Block Attestation Service CLI (see shell.nix bkyas_version for version)

--- a/example/README.md
+++ b/example/README.md
@@ -2,10 +2,3 @@
 
 A small wasm guest function written in go that uses all of the exported SDK 
 functions.
-
-## Dependencies
-
-- Go (see go.mod for version)
-- Tinygo v0.34.0
-- jq
-- Block Attestation Service CLI (see shell.nix bkyas_version for version)

--- a/example/README.md
+++ b/example/README.md
@@ -5,7 +5,7 @@ functions.
 
 ## Dependencies
 
-- Go 1.22
-- Tinygo v0.32.0
+- Go (see go.mod for version)
+- Tinygo v0.34.0
 - jq
-- Block Attestation Service CLI version fd9f4e8
+- Block Attestation Service CLI (see shell.nix for version)

--- a/nix/fetch-bky-as.sh
+++ b/nix/fetch-bky-as.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+bin=$1
+commit=$2
+os=$3
+arch=$4
+
+mkdir -p $bin
+
+echo -n "Getting commit of current bky-as..."
+current_version_commit=""
+if [[ -e $bin/bky-as ]]; then
+    current_version_commit=$($bin/bky-as inspect | jq -r .Build.Commit)
+    echo "'$current_version_commit'"
+else
+    echo "no current version"
+fi
+
+if [[ $commit == "latest" ]]; then
+  echo -n "Getting the latest commit..."
+  commit=$(gh api repos/blocky/delphi/commits --jq '.[0].sha')
+  echo "'$commit'"
+fi
+
+if [[ $current_version_commit != "$commit" ]]; then
+    echo "Versions differ ...updating"
+    aws s3 cp "s3://blocky-internal-release/delphi/cli/${commit}/${os}_${arch}" "${bin}/bky-as"
+    chmod +x "$bin/bky-as"
+else
+    echo "Version up to date"
+fi

--- a/nix/mkDevShell.nix
+++ b/nix/mkDevShell.nix
@@ -1,6 +1,6 @@
 {
   pkgs,
-  version,
+  bkyAsVersion,
   devDependencies,
 }:
 let
@@ -10,9 +10,9 @@ let
 
   isCommit = x: builtins.match "^[0-9a-f]{40}$" x != null;
 
-  bky-as-stable = pkgs.stdenv.mkDerivation {
+  bkyAsStable = pkgs.stdenv.mkDerivation {
     pname = "bky-as";
-    version = version;
+    version = bkyAsVersion;
     src = builtins.fetchurl {
       url = "https://github.com/blocky/attestation-service-demo/releases/download/${version}/bky-as_${goos}_${goarch}";
     };
@@ -23,15 +23,15 @@ let
   };
 
   stableShell = pkgs.mkShell {
-    packages = devDependencies ++ [ bky-as-stable ];
+    packages = devDependencies ++ [ bkyAsStable ];
     shellHook = ''
       echo "Stable bky-as version: ${version}"
     '';
   };
 
-  bky-as-unstable = pkgs.stdenv.mkDerivation {
+  bkyAsUnstable = pkgs.stdenv.mkDerivation {
     pname = "bky-as";
-    version = version;
+    version = bkyAsVersion;
     src = ./fetch-bky-as.sh;
     unpackPhase = ":";
     installPhase = ''
@@ -57,7 +57,7 @@ let
     '';
   };
 in
-if isCommit version || version == "latest" then
+if isCommit bkyAsVersion || bkyAsVersion == "latest" then
   unstableShell
 else
   # If the version is not a commit hash or "latest", we assume it is a stable

--- a/nix/mkDevShell.nix
+++ b/nix/mkDevShell.nix
@@ -22,7 +22,7 @@ let
     '';
   };
 
-  stableShell = pkgs.mkShellNoCC {
+  stableShell = pkgs.mkShell {
     packages = devDependencies ++ [ bky-as-stable ];
     shellHook = ''
       echo "Stable bky-as version: ${version}"
@@ -39,7 +39,7 @@ let
     '';
   };
 
-  unstableShell = pkgs.mkShellNoCC {
+  unstableShell = pkgs.mkShell {
     packages =
       devDependencies
       ++ [ bky-as-unstable ]

--- a/nix/mkDevShell.nix
+++ b/nix/mkDevShell.nix
@@ -1,0 +1,65 @@
+{
+  pkgs,
+  version,
+  devDependencies,
+}:
+let
+  system = import ./system.nix { pkgs = pkgs; };
+  goos = system.goos;
+  goarch = system.goarch;
+
+  isCommit = x: builtins.match "^[0-9a-f]{40}$" x != null;
+
+  bky-as-stable = pkgs.stdenv.mkDerivation {
+    pname = "bky-as";
+    version = version;
+    src = builtins.fetchurl {
+      url = "https://github.com/blocky/attestation-service-demo/releases/download/${version}/bky-as_${goos}_${goarch}";
+    };
+    unpackPhase = ":";
+    installPhase = ''
+      install -D -m 555 $src $out/bin/bky-as
+    '';
+  };
+
+  stableShell = pkgs.mkShellNoCC {
+    packages = devDependencies ++ [ bky-as-stable ];
+    shellHook = ''
+      echo "Stable bky-as version: ${version}"
+    '';
+  };
+
+  bky-as-unstable = pkgs.stdenv.mkDerivation {
+    pname = "bky-as";
+    version = version;
+    src = ./fetch-bky-as.sh;
+    unpackPhase = ":";
+    installPhase = ''
+      install -D -m 555 $src $out/bin/fetch-bky-as.sh
+    '';
+  };
+
+  unstableShell = pkgs.mkShellNoCC {
+    packages =
+      devDependencies
+      ++ [ bky-as-unstable ]
+      #dependencies required by the fetch script
+      ++ [
+        pkgs.gh
+        pkgs.awscli2
+        pkgs.jq
+      ];
+    shellHook = ''
+      bin=$(pwd)/tmp/bin
+      fetch-bky-as.sh $bin ${version} ${goos} ${goarch}
+      export PATH=$bin:$PATH
+      echo "Unstable bky-as version: ${version}"
+    '';
+  };
+in
+if isCommit version || version == "latest" then
+  unstableShell
+else
+  # If the version is not a commit hash or "latest", we assume it is a stable
+  # release version.
+  stableShell

--- a/nix/mkDevShell.nix
+++ b/nix/mkDevShell.nix
@@ -14,7 +14,7 @@ let
     pname = "bky-as";
     version = bkyAsVersion;
     src = builtins.fetchurl {
-      url = "https://github.com/blocky/attestation-service-demo/releases/download/${version}/bky-as_${goos}_${goarch}";
+      url = "https://github.com/blocky/attestation-service-demo/releases/download/${bkyAsVersion}/bky-as_${goos}_${goarch}";
     };
     unpackPhase = ":";
     installPhase = ''
@@ -25,7 +25,7 @@ let
   stableShell = pkgs.mkShell {
     packages = devDependencies ++ [ bkyAsStable ];
     shellHook = ''
-      echo "Stable bky-as version: ${version}"
+      echo "Stable bky-as version: ${bkyAsVersion}"
     '';
   };
 
@@ -42,7 +42,7 @@ let
   unstableShell = pkgs.mkShell {
     packages =
       devDependencies
-      ++ [ bky-as-unstable ]
+      ++ [ bkyAsUnstable ]
       #dependencies required by the fetch script
       ++ [
         pkgs.gh
@@ -51,9 +51,9 @@ let
       ];
     shellHook = ''
       bin=$(pwd)/tmp/bin
-      fetch-bky-as.sh $bin ${version} ${goos} ${goarch}
+      fetch-bky-as.sh $bin ${bkyAsVersion} ${goos} ${goarch}
       export PATH=$bin:$PATH
-      echo "Unstable bky-as version: ${version}"
+      echo "Unstable bky-as version: ${bkyAsVersion}"
     '';
   };
 in

--- a/nix/system.nix
+++ b/nix/system.nix
@@ -1,0 +1,16 @@
+{ pkgs }:
+let
+  system = pkgs.lib.strings.splitString "-" pkgs.stdenv.hostPlatform.system;
+  arch = builtins.elemAt (system) 0;
+  os = builtins.elemAt (system) 1;
+in
+{
+  goos = os;
+  goarch =
+    if arch == "x86_64" then
+      "amd64"
+    else if arch == "aarch64" then
+      "arm64"
+    else
+      throw "unknown arch '${arch}', supported arches are 'x86_64' and 'aarch64'";
+}

--- a/shell.nix
+++ b/shell.nix
@@ -3,14 +3,7 @@
   # the development shell. This value should be updated as the version of
   # the bky-as cli the example test works against is updated.
   #
-  # This default value can be overwritten from the command line by using a valid
-  # semver tag to grab a stable version, a git commit to grab a specific unstable
-  # version, or "latest" to grab the latest unstable version, e.g.
-  #   `nix-shell --pure --argstr bkyas_version v0.1.0-beta.5`
-  #   `nix-shell --pure --argstr bkyas_version <full git commit sha>`
-  #   `nix-shell --pure --argstr bkyas_version latest`
-  # or use the default value by omitting the argument, e.g.
-  #   `nix-shell --pure`
+  # This default value can be overwritten from the command line.
   bkyas_version ? "e7a2c061da429c66dcfadaf6007e0a4161fea6dc",
 }:
 let

--- a/shell.nix
+++ b/shell.nix
@@ -6,11 +6,11 @@
   # This default value can be overwritten from the command line by using a valid
   # semver tag to grab a stable version, a git commit to grab a specific unstable
   # version, or "latest" to grab the latest unstable version, e.g.
-  #   `nix-shell --argstr bkyas_version v0.1.0-beta.5`
-  #   `nix-shell --argstr bkyas_version <full git commit sha>`
-  #   `nix-shell --argstr bkyas_version latest`
+  #   `nix-shell --pure --argstr bkyas_version v0.1.0-beta.5`
+  #   `nix-shell --pure --argstr bkyas_version <full git commit sha>`
+  #   `nix-shell --pure --argstr bkyas_version latest`
   # or use the default value by omitting the argument, e.g.
-  #   `nix-shell`
+  #   `nix-shell --pure`
   bkyas_version ? "e7a2c061da429c66dcfadaf6007e0a4161fea6dc",
 }:
 let
@@ -27,15 +27,18 @@ mkDevShell {
 
   version = bkyas_version;
 
+  # Note that these package versions are determined by the nixpkgs version
+  # version used to build the shell.
   devDependencies = [
     pkgs.git # for project management
     pkgs.gnumake # for project management
-    pkgs.go_1_22 # for prepping for building wasm
+    pkgs.go # for prepping for building wasm, golangci-lint, and easyjson
     pkgs.golangci-lint # for linting go files
     pkgs.easyjson # for generating json marshaling go code
     pkgs.gotools # for tools like goimports
     pkgs.jq # for processing data in examples
     pkgs.nixfmt-rfc-style # for formatting nix files
     pkgs.tinygo # for building wasm
+    pkgs.toybox # include common unix commands for convenience
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,41 @@
+{
+  # This value controls the default version of the bky-as cli that is setup in
+  # the development shell. This value should be updated as the version of
+  # the bky-as cli the example test works against is updated.
+  #
+  # This default value can be overwritten from the command line by using a valid
+  # semver tag to grab a stable version, a git commit to grab a specific unstable
+  # version, or "latest" to grab the latest unstable version, e.g.
+  #   `nix-shell --argstr bkyas_version v0.1.0-beta.5`
+  #   `nix-shell --argstr bkyas_version <full git commit sha>`
+  #   `nix-shell --argstr bkyas_version latest`
+  # or use the default value by omitting the argument, e.g.
+  #   `nix-shell`
+  bkyas_version ? "e7a2c061da429c66dcfadaf6007e0a4161fea6dc",
+}:
+let
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.11";
+  pkgs = import nixpkgs {
+    config = { };
+    overlays = [ ];
+  };
+
+  mkDevShell = import ./nix/mkDevShell.nix;
+in
+mkDevShell {
+  pkgs = pkgs;
+
+  version = bkyas_version;
+
+  devDependencies = [
+    pkgs.git # for project management
+    pkgs.gnumake # for project management
+    pkgs.go_1_22 # for prepping for building wasm
+    pkgs.golangci-lint # for linting go files
+    pkgs.easyjson # for generating json marshaling go code
+    pkgs.gotools # for tools like goimports
+    pkgs.jq # for processing data in examples
+    pkgs.nixfmt-rfc-style # for formatting nix files
+    pkgs.tinygo # for building wasm
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -24,6 +24,7 @@ mkDevShell {
   # version used to build the shell.
   devDependencies = [
     pkgs.git # for project management
+    pkgs.less # for viewing files
     pkgs.gnumake # for project management
     pkgs.go # for prepping for building wasm, golangci-lint, and easyjson
     pkgs.golangci-lint # for linting go files

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@
   # the bky-as cli the example test works against is updated.
   #
   # This default value can be overwritten from the command line.
-  bkyas_version ? "e7a2c061da429c66dcfadaf6007e0a4161fea6dc",
+  bkyAsVersion ? "e7a2c061da429c66dcfadaf6007e0a4161fea6dc",
 }:
 let
   nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.11";
@@ -18,7 +18,7 @@ in
 mkDevShell {
   pkgs = pkgs;
 
-  version = bkyas_version;
+  bkyAsVersion = bkyAsVersion;
 
   # Note that these package versions are determined by the nixpkgs version
   # version used to build the shell.


### PR DESCRIPTION
## Describe your changes
This PR adds nix env management to allow for the specification of the bky-as CLI version and other project dependencies.

The nix configuration specifies `mkShell` rather than `mkShellNoCC` since we are using cgo. Since we are compiling with tinygo (it embeds Clang) we don't actually need a c compiler to build, but the linter expects the c files to run `typecheck`. 

## Related Jira cards
https://blocky.atlassian.net/browse/BKY-6544

## Notes for reviewers
1. the linter only works in --pure mode for me, something to do with how C is getting accessed, likely some interaction between my local environment and nix. Does `make lint` work for you when not in pure mode (`nix-shell`)? 
2. The packages are not directly pinned, but rather are pinned based on the fact that they are being pulled from a specific version of nixpkgs. I figured we could punt on figuring out the way we want to pin specific packages to a specific version later (all the packages from nixpkgs 24.11 seem to be happy together). 

## Checklist before requesting a review
If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [x] Dependencies in `go.mod` only reference tagged or `main` branch commits
- [x] I have run `make pre-pr` and all checks have passed.
- [x] DTO structs have been updated via `make generate`
- [x] The example in the `example` directory has been updated to reflect 
  these changes, if applicable.
- [x] This PR is small. 
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
