### PR TITLE
[BKY-6521] Attestation-service repo name change

### DIFF
--- a/nix/mkDevShell.nix
+++ b/nix/mkDevShell.nix
@@ -14,7 +14,7 @@ let
     pname = "bky-as";
     version = bkyAsVersion;
     src = builtins.fetchurl {
-      url = "https://github.com/blocky/attestation-service-demo/releases/download/${bkyAsVersion}/bky-as_${goos}_${goarch}";
+      url = "https://github.com/blocky/attestation-service-cli/releases/download/${bkyAsVersion}/bky-as_${goos}_${goarch}";
     };
     unpackPhase = ":";
     installPhase = ''


### PR DESCRIPTION
## Describe your changes
This PR updates the URL for fetching release binaries as the repository name has changed from attestation-service-demo to attestation-service-cli

## Related Jira cards
https://blocky.atlassian.net/browse/BKY-6521

## Notes for reviewers
none

## Checklist before requesting a review

If any of these checks are missing, please provide an explanation.

- [ ] I have updated README files, if applicable.
- [ ] Dependencies in `go.mod` only reference tagged or `main` branch commits
- [ ] I have run `nix-shell --pure --run "make pre-pr"` and all checks have
  passed.
- [ ] Test wasm in test/testdata has been updated to reflect sdk changes, if
  applicable.
- [ ] This PR is small.
    - Otherwise, justify here:
- [ ] This PR does not require external communication
    - Otherwise, describe requirements here:
