### PR TITLE
[BKY-6673] Fail mkshell on error

### DIFF
--- a/nix/mkDevShell.nix
+++ b/nix/mkDevShell.nix
@@ -25,6 +25,7 @@ let
   stableShell = pkgs.mkShell {
     packages = devDependencies ++ [ bkyAsStable ];
     shellHook = ''
+      set -e
       echo "Stable bky-as version: ${bkyAsVersion}"
     '';
   };
@@ -50,6 +51,7 @@ let
         pkgs.jq
       ];
     shellHook = ''
+      set -e
       bin=$(pwd)/tmp/bin
       fetch-bky-as.sh $bin ${bkyAsVersion} ${goos} ${goarch}
       export PATH=$bin:$PATH


### PR DESCRIPTION
## Describe your changes

Previously, when creating a shell with `nix-shell` if there was an error while
setting up the shell, we would received a notification but would still end up
in a nix-shell.  That tended to create some confusing results.  Here, we update
the creation so the creation terminates on a failure.

## Related Jira cards

[bky-6673](https://blocky.atlassian.net/browse/BKY-6673)

## Notes for reviewers

None

## Checklist before requesting a review

If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [x] Dependencies in `go.mod` only reference tagged or `main` branch commits
- [x] I have run `nix-shell --pure --run "make pre-pr"` and all checks have
  passed.
- [x] Test wasm in test/testdata has been updated to reflect sdk changes, if
  applicable.
- [x] This PR is small.
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
