### PR TITLE
[Chore] unset e after shell hook

### DIFF
--- a/nix/mkDevShell.nix
+++ b/nix/mkDevShell.nix
@@ -27,6 +27,7 @@ let
     shellHook = ''
       set -e
       echo "Stable bky-as version: ${bkyAsVersion}"
+      set +e
     '';
   };
 
@@ -56,6 +57,7 @@ let
       fetch-bky-as.sh $bin ${bkyAsVersion} ${goos} ${goarch}
       export PATH=$bin:$PATH
       echo "Unstable bky-as version: ${bkyAsVersion}"
+      set +e
     '';
   };
 in


### PR DESCRIPTION
## Describe your changes
return the shell environment to not exit on error after shell setup is completed.

## Related Jira cards
none

## Notes for reviewers
related: https://github.com/blocky/attestation-service-examples/pull/53

## Checklist before requesting a review

If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [x] Dependencies in `go.mod` only reference tagged or `main` branch commits
- [x] I have run `nix-shell --pure --run "make pre-pr"` and all checks have
  passed.
- [x] Test wasm in test/testdata has been updated to reflect sdk changes, if
  applicable.
- [x] This PR is small.
    - Otherwise, justify here:
- [x] This PR does not require external communication
    - Otherwise, describe requirements here:
